### PR TITLE
add 3rd party tools for linkit7697

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ Developing something relates to LINE Simple Beacon? Feel free to get in touch wi
 | https://github.com/pizayanz/pxt-linebeacon | LINE Beacon implementation for micro:bit | hisayan | MIT | ![stars](http://githubbadges.com/star.svg?repo=pxt-linebeacon&user=pizayanz) |
 | https://github.com/9wick/obniz-line-simple-beacon | LINE Beacon library for obniz | 9wick | MIT | ![stars](http://githubbadges.com/star.svg?repo=obniz-line-simple-beacon&user=9wick) |
 | https://github.com/taichunmin/line-simplebeacon-esp32 | LINE Beacon Sample for esp32 | taichunmin | MIT | ![stars](http://githubbadges.com/star.svg?repo=line-simplebeacon-esp32&user=taichunmin) |
+| https://github.com/taichunmin/line-simplebeacon-linkit7697 | LINE Beacon Sample for linkit7697 | taichunmin | MIT | ![stars](http://githubbadges.com/star.svg?repo=line-simplebeacon-linkit7697&user=taichunmin) |


### PR DESCRIPTION
The MediaTek Linkit 7697 board is very common in Taiwan. So I write a LINE Simple Beacon Sample for it.