### PR TITLE
ISSUE 17: add repository field in package.json

### DIFF
--- a/tools/line-simplebeacon-nodejs-sample/package.json
+++ b/tools/line-simplebeacon-nodejs-sample/package.json
@@ -11,5 +11,10 @@
   },
   "scripts": {
     "test": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/line/line-simple-beacon.git",
+    "directory": "tools/line-simplebeacon-nodejs-sample"
   }
 }


### PR DESCRIPTION
#17 

**BEFORE**

```
$ npm install
(node:6273) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.
npm WARN package.json line_simplebeacon@0.0.2 No repository field.
npm WARN deprecated mkdirp@0.5.1: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
npm WARN optional dep failed, continuing xpc-connection@0.1.4
...
```

**AFTER**

```
$ npm install
(node:6827) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.
npm WARN optional dep failed, continuing xpc-connection@0.1.4
npm WARN deprecated mkdirp@0.5.1: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
...
```
